### PR TITLE
More permissive regex for mimeType

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -177,7 +177,7 @@
     },
     "mimeType": {
       "type": "string",
-      "pattern": "^[\\sa-z0-9\\-+;\\.=\\/]+$",
+      "pattern": "[a-zA-Z0-9!#$%^&\\*_\\-\\+{}\\|'.`~]+/[a-zA-Z0-9!#$%^&\\*_\\-\\+{}\\|'.`~]+",
       "description": "The MIME type of the HTTP message."
     },
     "operation": {


### PR DESCRIPTION
The regex used for mimeType is too restrictive. This change allows for values that meet the criteria described in [RFC 2045](http://tools.ietf.org/html/rfc2045) and [RFC 2046](http://tools.ietf.org/html/rfc2046).

Hat tip to @mnot for his regex, which he [posted here](http://lists.w3.org/Archives/Public/xml-dist-app/2003Jul/0064.html).