### PR TITLE
Update schema in npm and bower

### DIFF
--- a/schemas/v2.0/bower.json
+++ b/schemas/v2.0/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-schema",
-  "version": "2.0.0-b6411e9",
+  "version": "2.0.0-96305d9",
   "homepage": "https://github.com/wordnik/swagger-schema",
   "authors": [
     "''"

--- a/schemas/v2.0/package.json
+++ b/schemas/v2.0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-schema-official",
-  "version": "2.0.0-a33091a",
+  "version": "2.0.0-96305d9",
   "description": "Swagger JSON Schema ",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fixes #335 `swagger-schema-official@2.0.0-0ac571a` is the latest in npm