### PR TITLE
versions/2.0: Add a 'time' type

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -92,6 +92,7 @@ byte | `string` | `byte` |
 boolean | `boolean` | |
 date | `string` | `date` | As defined by `full-date` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+time | `string` | `time` | As defined by `full-time` - [RFC3339](http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
 
 ### Schema


### PR DESCRIPTION
Having human-readable times that are not associated with dates is
frequently useful.  For example, this lets you say things like:

* "tea is at 3:15pm" (localtime)
* "the weekly meeting is at 12:00 UTC"

Using the ISO 8061 [time][1] [formats][2] should make it easy for both
people and software to interact with the values.

Since Swagger-specified APIs are often consumed and produced from
JavaScript, and since JavaScript has limited time-handling
capabilities, I thought I'd dig a bit deeper in that direction.
Support for date-less ISO 8601 times in native JavaScript is [unclear][3],
but Firefox 31.5 in seems to support times with a 'T' prefix:

  > new Date('12:34')
  Invalid Date
  > new Date('T12:34')
  Date 1970-01-01T20:34:00.000Z
  > new Date('T12:34Z')
  Date 1970-01-01T12:34:00.000Z

which, in conjunction with [Date.prototype.toTimeString()][4] and other
time-specific maniplations is probably sufficient for most purposes.
Chromium 41.0, on the other hand, gave 'Invalid Date' warnings for
each of those cases, so JavaScript consumers may want to pad their
times with dummy date information.  Moment.js also requires a date
part and [doesn't support stand-alone times][5].

On the other hand, there are [time-only pickers in JavaScript][6].

Python also has a [time-only format][7] as [does][8] [Java][9].  Go just
has a date-time type, but it [can parse time-only strings][10].

[1]: http://en.wikipedia.org/wiki/ISO_8601#Times
[2]: http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14
[3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Parameters
[4]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString
[5]: http://momentjs.com/docs/#supported-iso-8601-strings
[6]: https://angular-ui.github.io/bootstrap/#/timepicker
[7]: https://docs.python.org/3/library/datetime.html#datetime.time
[8]: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetTime.html
[9]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalTime.html
[10]: http://golang.org/pkg/time/#Parse