### PR TITLE
Examples for relative/separate schema in Reference Object

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -1126,6 +1126,27 @@ Field Name | Type | Description
 $ref: '#/definitions/Pet'
 ```
 
+##### Relative Schema File Example
+```js
+{
+  "$ref": "Pet.json"
+}
+```
+
+```yaml
+$ref: 'Pet.yaml'
+
+##### Relative Files With Embedded Schema Example
+```js
+{
+  "$ref": "definitions.json#/Pet"
+}
+```
+
+```yaml
+$ref: 'definitions.yaml#/Pet'
+
+
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is based on the [JSON Schema Specification Draft 4](http://json-schema.org/) and uses a predefined subset of it. On top of this subset, there are extensions provided by this specification to allow for more complete documentation.

--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -1135,6 +1135,7 @@ $ref: '#/definitions/Pet'
 
 ```yaml
 $ref: 'Pet.yaml'
+```
 
 ##### Relative Files With Embedded Schema Example
 ```js
@@ -1145,7 +1146,7 @@ $ref: 'Pet.yaml'
 
 ```yaml
 $ref: 'definitions.yaml#/Pet'
-
+```
 
 #### <a name="schemaObject"></a>Schema Object
 


### PR DESCRIPTION
@webron Created a separate PR for updated spec examples for separate files, to polish off #384 
This was all in support of https://github.com/swagger-api/swagger-js/issues/417, which is not yet merged to master, AFAIK. Not sure if you want this in master docs until tooling supports it, but your call.