### PR TITLE
Fix '$ref' validation.

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -1484,6 +1484,7 @@
     },
     "jsonReference": {
       "type": "object",
+      "required": ["$ref"],
       "additionalProperties": false,
       "properties": {
         "$ref": {


### PR DESCRIPTION
Fix validation, for example in following case:
```json
{
    "swagger": "2.0",
    "info": {
        "version": "0.0.0",
        "title": "Simple API"
    },
    "paths": {
        "/": {
            "get": {
                "responses": {
                    "200": {
                    }
                }
            }
        }
    }
}
```