### PR TITLE
Make "required" mandatory for "path" parameters.

### DIFF
--- a/examples/v2.0/yaml/petstore.yaml
+++ b/examples/v2.0/yaml/petstore.yaml
@@ -60,6 +60,7 @@ paths:
       parameters:
         - name: petId
           in: path
+          required: true
           description: The id of the pet to retrieve
           type: string
       responses:

--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -770,6 +770,7 @@
           "$ref": "#/definitions/vendorExtension"
         }
       },
+      "required": ["required"],
       "properties": {
         "required": {
           "type": "boolean",


### PR DESCRIPTION
Fixes #406 
Based on discussion from apigee-127/swagger-converter/pull/37
Example:
```json
{
    "swagger": "2.0",
    "info": {
        "version": "0.0.0",
        "title": "Simple API"
    },
    "paths": {
        "/{foo}": {
            "parameters": [
                {
                    "name": "foo",
                    "in": "path",
                    "type": "string"
                }
            ],
            "get": {
                "responses": {
                    "200": {
                        "description": "OK"
                    }
                }
            }
        }
    }
}
```