### PR TITLE
Fix 'host' regex and format: uri conflict

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -27,9 +27,8 @@
     },
     "host": {
       "type": "string",
-      "format": "uri",
       "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
-      "description": "The fully qualified URI to the host of the API."
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
     },
     "basePath": {
       "type": "string",


### PR DESCRIPTION
I believe the `"format": "uri"` contradicts the regex pattern below in the `host` specification.

RFC 2396 URI require a scheme (e.g. 'http') but the swagger schema documentation https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swaggerHost and the `pattern` regex specifically exclude schemes.

The description 'fully qualified URI' is therefore incorrect.

I've removed `"format": "uri"` and updated the description to better explain the field and gave an example. I didn't mention the optional `:<port number>` as I thought that might be too much detail for a description, but maybe that would be helpful too?

Before making this change I tested the json-schema `"format": "hostname"` in case that gave the desired validations, but that hostname does not accept port numbers, so this looks like it needs to be a custom format as it is NOT a rfc1034 compliant hostname as referenced from the json-schema docs, http://json-schema.org/latest/json-schema-validation.html#anchor114