### PR TITLE
Permit a new top-level entry 'pathDefinitions', capable of containing…

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -52,6 +52,9 @@
     "definitions": {
       "$ref": "#/definitions/definitions"
     },
+    "pathDefinitions": {
+      "$ref": "#/definitions/paths"
+    },
     "parameters": {
       "$ref": "#/definitions/parameterDefinitions"
     },


### PR DESCRIPTION
… a list of Path Items.

At the moment, one can refer to an external path definition using a reference object, eg:

    "paths": {
        "/icecream": {
        	"$ref": "example.com/#/pathDefinitions/icecream"
        }
    }

However, the reference must be to a definition located in an external document. It cannot refer to the referring document (using '#/' syntax), because there is nowehere in the Swagger API spec other than the 'paths' item where it is legal to place a Path Item object.

In other words, this change permits the previously-illegal:

    "pathDefinitions": {
        "IceCreamPath": {
            "get": {
                "summary": "Obtain ice cream"
            }
        }
    }
    "paths": {
        "/icecream": {
        	"$ref": "#/pathDefinitions/IceCreamPath"
        }
    }

This is consistent with other aspects of Swagger including parameters, definitions and schemas.

Once we can refer to existing path definitions by name like this, we can add high-level semantic information to the API specification by cross-linking related paths and/or operations - perhaps something like:

    "pathDefinitions": {
        "IceCreamPath": {
            "get": {
                "summary": "Obtain ice cream"
            },
            "links": [
                {
                    "rel": "self",
                    "href": {
                        "$ref": "#/pathDefinitions/IceCreamPath"
                    }
                },
                {
                    "rel": "topping",
                    "href": {
                        "$ref": "#/pathDefinitions/ToppingPath"
                    }
                }
            ]
        },
        "ToppingPath": {
            "get": {
                "summary": "Obtain chocolate topping"
            }
        }
    },
    "paths": {
        "/icecream": {
            "$ref": "#/pathDefinitions/IceCreamPath"
        },
        "/topping": {
            "$ref": "#/pathDefinitions/ToppingPath"
        }
