### PR TITLE
Add type values to Security Scheme Object

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -2124,7 +2124,7 @@ Allows the definition of a security scheme that can be used by the operations. S
 ##### Fixed Fields
 Field Name | Type | Validity | Description
 ---|:---:|---|---
-<a name="securitySchemeType"></a>type | `string` | Any | **Required.** The type of the security scheme. Valid values are `"basic"`, `"apiKey"` or `"oauth2"`.
+<a name="securitySchemeType"></a>type | `string` | Any | **Required.** The type of the security scheme. Valid values are `"basic"`, `"digest"`, `"negotiate"`, `"apiKey"` or `"oauth2"`.
 <a name="securitySchemeDescription"></a>description | `string` | Any | A short description for security scheme.
 <a name="securitySchemeName"></a>name | `string` | `apiKey` | **Required.** The name of the header or query parameter to be used.
 <a name="securitySchemeIn"></a>in | `string` | `apiKey` | **Required** The location of the API key. Valid values are `"query"` or `"header"`.


### PR DESCRIPTION
To support Digest and Negotiate (for Kerberos) it would be nice if the type values would be added to the specification.