### PR TITLE
2.0: stricter validation of additionalProperties

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -991,10 +991,12 @@
               "$ref": "#/definitions/schema"
             },
             {
-              "type": "boolean"
+              "description": "false",
+              "type": "boolean",
+              "enum": [ false ]
             }
           ],
-          "default": {}
+          "default": false
         },
         "type": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/type"


### PR DESCRIPTION
Following [clarification of `additionalProperties` for a schema](/swagger-api/swagger-codegen/issues/1318#issuecomment-146302879) by @webron:
- we now accept only `false` or a schema for `additionalProperties`: `true` is now rejected.
- `false` is the new default for `additionalProperties` (instead of `{}` which means "anything is accepted" in JSON Schema).