### PR TITLE
RFC: Add '$schema' property at root of the spec 2.x

### DIFF
--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -22,6 +22,17 @@
       ],
       "description": "The Swagger version of this document."
     },
+    "$schema": {
+      "allOf": [
+        {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/$schema"
+        },
+        {
+          "description": "JSON schema for validation of this Swagger specification",
+          "default": "http://swagger.io/schemas/v2.0/schema.json"
+        }
+      ]
+    },
     "info": {
       "$ref": "#/definitions/info"
     },

--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -120,6 +120,7 @@ Field Name | Type | Description
 <a name="swaggerSecurity"></a>security | [[Security Requirement Object](#securityRequirementObject)] | A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). Individual operations can override this definition.
 <a name="swaggerTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags used by the specification with additional metadata. The order of the tags can be used to reflect on their order by the parsing tools. Not all tags that are used by the [Operation Object](#operationObject) must be declared. The tags that are not declared may be organized randomly or based on the tools' logic. Each tag name in the list MUST be unique.
 <a name="swaggerExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation.
+<a name="swaggerJSONSchema"></a>$schema | `string` | URI to the JSON Schema for Swagger 2 for basic validation of this specification. The default value is [http://swagger.io/schemas/v2.0/schema.json](http://swagger.io/schemas/v2.0/schema.json)
 
 ##### Patterned Objects 
 


### PR DESCRIPTION
JSON schema specifies a standard way for a document to tell what JSON Schema document can be used to validate it. This is the `/$schema` property.

Unfortunately this property is strictly disallowed in the Swagger 2.0 JSON schema (`/additionalProperties` is set to false): Swagger authors decided to use instead the `/swagger` property. This is enough for humans, but the presence of `/$schema` could be useful for machines to
validate Swagger specifications that use vendor extensions and for which a JSON schema specifying the schema of those extensions is available. That would allow to write a Swagger spec that explicitely points to those extensions.

So we add `/$schema`, with a default value of http://swagger.io/schema/v2.0/schema.json (see
[swagger-api/swagger.io#48](https://github.com/swagger-api/swagger.io/issues/#48) which is a request to have canonical URLs for Swagger JSON schemas).

As this feature is incompatible with the 2.0 schema (`/$schema` is forbidden in 2.0 because `/additionalProperties` is [set to false](../blob/master/schemas/v2.0/schema.json#L11)), setting this value in a document will only be possible if a version 2.0.1/2.1 of the specification is published with that extension. So this patch is not designed to be directly merged to the existing schema, but instead to show the required changes to the spec to allow this feature.