### PR TITLE
Fix indentation of Person's name property in example

### DIFF
--- a/versions/2.0.md
+++ b/versions/2.0.md
@@ -1709,10 +1709,10 @@ Person:
       xml:
         attribute: true
     name:
-        type: string
-        xml:
-          namespace: http://swagger.io/schema/sample
-          prefix: sample
+      type: string
+      xml:
+        namespace: http://swagger.io/schema/sample
+        prefix: sample
 ```
 
 ```xml


### PR DESCRIPTION
https://github.com/swagger-api/swagger-spec/pull/484 fixed indentation of the name field, but the fields under name need to be unindented as well.